### PR TITLE
Added posible fix to robot movement on gotoPoint function and move function

### DIFF
--- a/LineTracking/follow-segment.h
+++ b/LineTracking/follow-segment.h
@@ -1,1 +1,10 @@
+/*
+ * follow_segment.h
+ */ 
+
+#ifndef FOLLOW_SEGMENT_H_
+#define FOLLOW_SEGMENT_H_
+
 void follow_segment();
+
+#endif /* FOLLOW_SEGMENT_H_ */

--- a/LineTracking/main.c
+++ b/LineTracking/main.c
@@ -57,7 +57,7 @@ void initialize() {
 	unsigned int counter;
 	
 	pololu_3pi_init(2000);
-	// play_from_program_space(mario1);
+	play_from_program_space(mario1);
 	// while(is_playing());
 	
 	while(!button_is_pressed(BUTTON_B)) {
@@ -224,12 +224,11 @@ void gotoPoint(int x, int y) {
 	{
 		changeDir(xdir);
 		
-		if (isMoved++ == 0)
+		if (!isMoved)
 		{
+			isMoved = 1;
 			set_motors(50,50);
 			delay_ms(50);
-			//set_motors(40,40);
-			//delay_ms(200);
 		}
 	}
 	
@@ -258,12 +257,11 @@ void gotoPoint(int x, int y) {
 	if (r3PI.y != y)
 	{
 		changeDir(ydir);
-		if (isMoved++ == 0)
+		if (!isMoved)
 		{
+			isMoved = 1;
 			set_motors(50,50);
 			delay_ms(50);
-			//set_motors(40,40);
-			//delay_ms(200);
 		}
 	}
 	
@@ -351,10 +349,10 @@ int move(int dir, int units)
 {
 	switch(dir)
 	{
-		case 0: gotoPoint(r3PI.x, r3PI.y + units);
-		case 1: gotoPoint(r3PI.x + units, r3PI.y);
-		case 2: gotoPoint(r3PI.x, r3PI.y - units);
-		case 3: gotoPoint(r3PI.x - units, r3PI.y);
+		case 0: gotoPoint(r3PI.x, r3PI.y + units); break;
+		case 1: gotoPoint(r3PI.x + units, r3PI.y); break;
+		case 2: gotoPoint(r3PI.x, r3PI.y - units); break;
+		case 3: gotoPoint(r3PI.x - units, r3PI.y); break;
 	}
 }
 
@@ -367,77 +365,6 @@ int main()
 	int gotoX = 4;
 	int gotoY = 2;
 	
-	// Welcome message
-	print("Hi");
-	delay_ms(1000);
-	
-	// Select start location
-	while (!button_is_pressed(BUTTON_A))
-	{
-		clear();
-		
-		print("Start loc: ");
-		
-		lcd_goto_xy(0, 1);
-		
-		print_long(r3PI.x);
-		print(" ");
-		print_long(r3PI.y);
-		
-		if (button_is_pressed(BUTTON_B))
-		r3PI.x < 5 ? r3PI.x++ : (r3PI.x = 0);
-		if (button_is_pressed(BUTTON_C))
-		r3PI.y < 5 ? r3PI.y++ : (r3PI.y = 0);
-		
-		delay_ms(100);
-	}
-	wait_for_button_release(BUTTON_A);
-	delay_ms(100);
-	
-	// Select start direction
-	while (!button_is_pressed(BUTTON_A))
-	{
-		clear();
-		
-		print("Start Dir: ");
-		
-		lcd_goto_xy(0, 1);
-		
-		print(NESW[r3PI.d]);
-		
-		if (button_is_pressed(BUTTON_B))
-		r3PI.d < 3 ? r3PI.d++ : (r3PI.d = 0);
-		
-		delay_ms(100);
-	}
-	wait_for_button_release(BUTTON_A);
-	delay_ms(100);
-	
-	// Select goto location
-	while (!button_is_pressed(BUTTON_A))
-	{
-		clear();
-		
-		print("Go loc: ");
-		
-		lcd_goto_xy(0, 1);
-		
-		print_long(gotoX); // x-coordinate
-		print(" ");
-		print_long(gotoY); // y-coordinate
-		
-		delay_ms(100);
-		
-		if (button_is_pressed(BUTTON_B))
-		gotoX < 5 ? gotoX++ : (gotoX = 0);
-		if (button_is_pressed(BUTTON_C))
-		gotoY < 5 ? gotoY++ : (gotoY = 0);
-		
-		delay_ms(100);
-	}
-	wait_for_button_release(BUTTON_A);
-	delay_ms(1000);
-	
 	gotoPoint(gotoX, gotoY);
 	print3PI(r3PI);
 	
@@ -445,6 +372,18 @@ int main()
 	{
 		gotoPoint(i, i);
 	}
+	print3PI(r3PI);
+	
+	move(SOUTH, 2);
+	print3PI(r3PI);
+	
+	gotoCorner(3);
+	print3PI(r3PI);
+	
+	move(SOUTH, 2);
+	print3PI(r3PI);
+	
+	gotoEdge(2);
 	print3PI(r3PI);
 	
 	while(1);


### PR DESCRIPTION
Added a fix for when robot first moves on grid during the gotoPoint function. When the robot first moves, it might go off the grid because of what the sensors sense.

Usually poor placement of the robot causes this but it happened before when it was placed well. This is a possible fix for it that has worked for me though it might be good to have a more intelligent response to this.

The move function also needed to take out the return statements and have the break keywords added in to properly work since the calls to gotoPoint in the function do not return anything.
